### PR TITLE
Simplify Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,14 @@
 language: c
-env:
-  global:
-    - GAPROOT=gaproot
-    - COVDIR=coverage
 
 addons:
   apt_packages:
     - libgmp-dev
     - libreadline-dev
-    - libgmp-dev:i386
-    - libreadline-dev:i386
-    - gcc-multilib
-    - g++-multilib
+    - zlib1g-dev
 
 matrix:
   include:
-    - env: GAPBRANCH=master ABI=64
-    - env: GAPBRANCH=master ABI=32
+    - env: GAPBRANCH=master
     - env: GAPBRANCH=stable-4.11
     - env: GAPBRANCH=stable-4.10
 
@@ -25,11 +17,10 @@ branches:
     - master
 
 before_script:
-  - export GAPROOT="$HOME/gap"
   - git clone https://github.com/gap-system/pkg-ci-scripts.git scripts
   - scripts/build_gap.sh
 script:
   - scripts/build_pkg.sh && scripts/run_tests.sh
 after_script:
-  - bash scripts/gather-coverage.sh
+  - scripts/gather-coverage.sh
   - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
This package contains no kernel extension, so there is no good reason to test
it on 32bit systems. Also, remove some obsolete stuff.